### PR TITLE
Remove before each - unnecessary when only one test

### DIFF
--- a/cypress/integration/moviepage_spec.js
+++ b/cypress/integration/moviepage_spec.js
@@ -1,10 +1,10 @@
-beforeEach(() => {
-  cy.fetchMovie('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2');
-  cy.visit('http://localhost:3000/movies/694919');
-});
-
 describe('The Film Vault Movie Page', () => {
   it("should contain all of a movie's details that resolve to truthy", () => {
+    cy.fetchMovie(
+      'GET',
+      'https://rancid-tomatillos.herokuapp.com/api/v1/movies/694919'
+    );
+    cy.visit('http://localhost:3000/movies/694919');
     cy.get('h2')
       .contains('Money Plane')
       .get('h3')


### PR DESCRIPTION
# Description
- Remove beforeEach on movepage_spec.js. Only one test and beforeEach was causing a test failure. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## How Has This Been Tested?
- [ ] Use console.log()
- [ ] Dev tools / react dev tools
- [ ] View in local host
- [ ] Verify acceptance criteria (if applicable)
- [x] Run cypress

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
